### PR TITLE
Changed the Date  attributes format for project and project_task

### DIFF
--- a/src/main/java/io/proyection/projection/domain/Project.java
+++ b/src/main/java/io/proyection/projection/domain/Project.java
@@ -1,5 +1,7 @@
 package io.proyection.projection.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import java.util.Date;
@@ -15,9 +17,11 @@ public class Project {
     @NotBlank(message="Nombre del proyecto es obligatorio")
     private String projectName;
     private String projectDescription;
-    @NotBlank(message="Fecha de inicio obligatoria")
+    @JsonFormat(pattern="yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    @Column(name = "start_date")
     private Date startDate;
-    @NotBlank(message="Fecha fin obligatoria")
+    @JsonFormat(pattern="yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    @Column(name = "estimated_end_date")
     private Date estimatedEndDate;
     private String createdBy;
     private Date dateCreated;

--- a/src/main/java/io/proyection/projection/domain/ProjectTask.java
+++ b/src/main/java/io/proyection/projection/domain/ProjectTask.java
@@ -1,5 +1,6 @@
 package io.proyection.projection.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -20,6 +21,7 @@ public class ProjectTask {
     private Date dateCreated;
     private String modifiedBy;
     private Date modifiedDate;
+    @JsonFormat(pattern="yyyy-MM-dd")
     private Date limitDate;
     private boolean done = false;
 


### PR DESCRIPTION
- I have added an annotation for Date attributes in Project and ProjectTask
- They are optional attributes to fill in and they can now display correctly in the user interface and be saved correctly as well in the database.